### PR TITLE
ci: skip upstream-only SageMaker upload in forks

### DIFF
--- a/.github/workflows/sagemaker_upload_pr_documentation.yml
+++ b/.github/workflows/sagemaker_upload_pr_documentation.yml
@@ -8,6 +8,10 @@ on:
 
 jobs:
   build:
+    # The reusable upload workflow needs organization secrets that are not
+    # available to public forks. Only run it in the upstream repository after
+    # the documentation build completed successfully.
+    if: ${{ github.repository == 'huggingface/hub-docs' && github.event.workflow_run.conclusion == 'success' }}
     uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@main
     with:
       package_name: sagemaker


### PR DESCRIPTION
The SageMaker PR upload reusable workflow requires HF_DOC_BUILD_PUSH and COMMENT_BOT_TOKEN organization secrets that are unavailable to public forks. Gate the upload job to the upstream repository and successful build runs so fork PRs do not report a false failure.